### PR TITLE
Ajustes no `create` e no `rename` das pastas e notas

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@ interface IProps {
 
 export default function Sidebar({ userData }: IProps) {
   return (
-    <div className="w-80 bg-gray-200 py-4 pr-6">
+    <div className="w-80 bg-gray-200 py-4 pr-6 overflow-y-hidden hover:overflow-y-auto">
       {userData?.folders.map((folder) => {
         return <FolderComp folder={folder} key={folder.id} />;
       })}

--- a/src/utils/useKeyDown.tsx
+++ b/src/utils/useKeyDown.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+export default function useKeyDown(callback: () => void, keys: string[]) {
+  const onKeyDown = (event: KeyboardEvent) => {
+    const wasAnyKeyPressed = keys.some((key) => key == event.key);
+
+    if (wasAnyKeyPressed) {
+      callback();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onKeyDown]);
+}


### PR DESCRIPTION
O que esse commit faz:

- Ajusta o `nome padrão` de quando uma nota e pasta são criadas como `New Folder(1)`, por exemplo
- Para fazer o ajuste teve que ser adicionado um `updater` para trazer as atualizações do rename para a pasta pai, já que quando uma nota ou uma pasta eram renomeadas, a pasta à qual elas pertenciam não recebia essa atualização.
- Quando apertada a tecla `Enter` para renomear uma nota ou uma pasta sai do input automaticamente, isso foi feito com um hook customizado `useKeyDown`, visto no site `Medium`

Link para o site: https://medium.com/@paulohfev/problem-solving-custom-react-hook-for-keydown-events-e68c8b0a371
